### PR TITLE
Update libraries

### DIFF
--- a/Firebase/build.gradle
+++ b/Firebase/build.gradle
@@ -27,5 +27,5 @@ android {
 
 dependencies {
     androidTestCompile project(':Common')
-    androidTestCompile 'com.firebase:firebase-client-android:2.5.1'
+    androidTestCompile 'com.firebase:firebase-client-android:2.5.2'
 }

--- a/Realm/build.gradle
+++ b/Realm/build.gradle
@@ -2,7 +2,7 @@ buildscript {
     dependencies {
         classpath dep.androidPlugin
         classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
-        classpath 'io.realm:realm-gradle-plugin:0.88.0'
+        classpath 'io.realm:realm-gradle-plugin:0.88.2'
     }
 }
 

--- a/SquiDB/build.gradle
+++ b/SquiDB/build.gradle
@@ -23,7 +23,8 @@ android {
 
 dependencies {
     androidTestCompile project(':Common')
-    compile 'com.yahoo.squidb:squidb:2.0.0'
-    compile 'com.yahoo.squidb:squidb-annotations:2.0.0'
-    apt 'com.yahoo.squidb:squidb-processor:2.0.0'
+    def squidbVersion = '2.0.2'
+    compile "com.yahoo.squidb:squidb:$squidbVersion"
+    compile "com.yahoo.squidb:squidb-annotations:$squidbVersion"
+    apt "com.yahoo.squidb:squidb-processor:$squidbVersion"
 }

--- a/requery/build.gradle
+++ b/requery/build.gradle
@@ -27,7 +27,7 @@ android {
 
 dependencies {
     androidTestCompile project(':Common')
-    def requeryVersion = '1.0.0-beta6'
+    def requeryVersion = '1.0.0-beta11'
     compile "io.requery:requery:${requeryVersion}"
     compile "io.requery:requery-android:${requeryVersion}"
     apt "io.requery:requery-processor:${requeryVersion}"

--- a/requery/src/main/java/de/greenrobot/performance/requery/AbstractIndexedStringEntity.java
+++ b/requery/src/main/java/de/greenrobot/performance/requery/AbstractIndexedStringEntity.java
@@ -13,7 +13,7 @@ public abstract class AbstractIndexedStringEntity {
     @Key
     public long _id;
 
-    @Index(name = "string_index")
+    @Index(value = "string_index")
     public String indexedString;
 
 }


### PR DESCRIPTION
New versions for Firebase, Realm, requery and squiDB.

requery required minor change due to `Index` annotation parameter naming change.
