### PR TITLE
Travis improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,20 @@
 language: android
 # Use the Travis Container-Based Infrastructure
 sudo: false
+
 jdk:
-  - oraclejdk7
-env:
-  global:
-    # increase adb timeout (2 minutes by default)
-    - ADB_INSTALL_TIMEOUT=8
-  matrix:
-    - ANDROID_SDKS=android-23,sysimg-23  ANDROID_TARGET=android-19  ANDROID_ABI=armeabi-v7a
+  - oraclejdk8
+
 android:
   components:
+    - platform-tools
     - tools
     - build-tools-23.0.2
     - android-23
     - extra-android-m2repository
-before_install:
-  - echo no | android create avd --force -n test -t $ANDROID_TARGET --abi $ANDROID_ABI
-  - emulator -avd test -no-skin -no-audio -no-window &
+
 before_script:
   - chmod +x gradlew
-  - chmod +x ./ci/wait_for_emulator
-  - ./ci/wait_for_emulator
-  - adb shell input keyevent 82 &
+
 script:
-    - TERM=dumb ./gradlew connectedCheck
+  - ./gradlew build

--- a/Common/build.gradle
+++ b/Common/build.gradle
@@ -13,7 +13,7 @@ android {
     defaultConfig {
         minSdkVersion rootProject.ext.minSdkVersion
 
-        buildConfigField "boolean", "RUN_PERFORMANCE_TESTS", "false"
+        buildConfigField "boolean", "RUN_PERFORMANCE_TESTS", "true"
     }
 }
 

--- a/Realm/build.gradle
+++ b/Realm/build.gradle
@@ -16,7 +16,7 @@ android {
 
     defaultConfig {
         applicationId 'de.greenrobot.performance.realm'
-        minSdkVersion 9
+        minSdkVersion 11
         targetSdkVersion rootProject.ext.targetSdkVersion
 
         testInstrumentationRunner 'android.test.InstrumentationTestRunner'

--- a/ci/wait_for_emulator
+++ b/ci/wait_for_emulator
@@ -1,17 +1,25 @@
 #!/bin/bash
 
+# https://github.com/travis-ci/travis-cookbooks/blob/precise-stable/ci_environment/android-sdk/files/default/android-wait-for-emulator
+
+set +e
+
 bootanim=""
 failcounter=0
+timeout_in_sec=360
+
 until [[ "$bootanim" =~ "stopped" ]]; do
-   bootanim=`adb -e shell getprop init.svc.bootanim 2>&1`
-   echo "$bootanim"
-   if [[ "$bootanim" =~ "not found" ]]; then
-      let "failcounter += 1"
-      if [[ $failcounter -gt 3 ]]; then
-        echo "Failed to start emulator"
-        exit 1
-      fi
-   fi
-   sleep 1
+  bootanim=`adb -e shell getprop init.svc.bootanim 2>&1 &`
+  if [[ "$bootanim" =~ "device not found" || "$bootanim" =~ "device offline"
+    || "$bootanim" =~ "running" ]]; then
+    let "failcounter += 1"
+    echo "Waiting for emulator to start"
+    if [[ $failcounter -gt timeout_in_sec ]]; then
+      echo "Timeout ($timeout_in_sec seconds) reached; failed to start emulator"
+      exit 1
+    fi
+  fi
+  sleep 1
 done
-echo "Done"
+
+echo "Emulator is ready"

--- a/requery/build.gradle
+++ b/requery/build.gradle
@@ -23,6 +23,10 @@ android {
 
         testInstrumentationRunner 'android.test.InstrumentationTestRunner'
     }
+
+    lintOptions {
+        ignore 'InvalidPackage'
+    }
 }
 
 dependencies {


### PR DESCRIPTION
- Resolve PermGen memory issue (use JDK 8).
- Improved emulator script.
- Only build, do not run the performance tests on travis. Now can enable perf tests by default.
- Only build to work around realm transformer failure (see #12)
